### PR TITLE
Crest update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name = "workflowV2",
-    version = "2.22303",
+    version = "2.3.0",
     author = "Patrick Neal",
     author_email = "prnmac12@gmail.com",
     description = ("An automation tool for QM calculations"),

--- a/workflowV2/calculator.py
+++ b/workflowV2/calculator.py
@@ -60,7 +60,7 @@ class Calculator:
 
         for index,content in enumerate(self.input):
             #with open('{0}/{1}-try{2}.{3}'.format(self.dir,self.jobname,self.try_count,self.program.infiles[index]),'w') as inputfile:
-            print(self.program.infiles[index])
+            log(self.program.infiles[index])
             with open(self.program.infiles[index].format(dir=self.dir,jobname=self.jobname,try_count=self.try_count), 'w') as inputfile:
                 inputfile.write(content)
 

--- a/workflowV2/calculator.py
+++ b/workflowV2/calculator.py
@@ -59,8 +59,6 @@ class Calculator:
             os.makedirs(self.dir)
 
         for index,content in enumerate(self.input):
-            #with open('{0}/{1}-try{2}.{3}'.format(self.dir,self.jobname,self.try_count,self.program.infiles[index]),'w') as inputfile:
-            log(self.program.infiles[index])
             with open(self.program.infiles[index].format(dir=self.dir,jobname=self.jobname,try_count=self.try_count), 'w') as inputfile:
                 inputfile.write(content)
 

--- a/workflowV2/calculator.py
+++ b/workflowV2/calculator.py
@@ -45,10 +45,10 @@ class Calculator:
     #file io#
         self.dir = os.path.abspath(jobname) + '/'
         self.basename_full = self.dir +  self.jobname + '-try{0}'.format(try_count) 
-        self.inputfile_full = self.dir +  self.jobname + '-try{0}'.format(try_count) + '.' + self.program.infiles[0]
-        self.outputfile_full = self.dir +  self.jobname + '-try{0}'.format(try_count) + '.' + self.program.outfiles[0]
-        self.inputfile_relative = self.jobname + '-try{0}'.format(try_count) + '.' + self.program.infiles[0]
-        self.outputfile_relative = self.jobname + '-try{0}'.format(try_count) + '.' + self.program.outfiles[0]
+        self.input_file_full = self.program.infiles[0].format(dir=self.dir,jobname=self.jobname,try_count=self.try_count)
+        self.outputfile_full = self.program.outfiles[0].format(dir=self.dir, jobname=self.jobname, try_count=self.try_count)
+        self.inputfile_relative = self.program.infiles[0].format(dir='',jobname=self.jobname,try_count=self.try_count)
+        self.outputfile_relative = self.program.outfiles[0].format(dir='', jobname=self.jobname, try_count=self.try_count)
 
     ############
     #input file#
@@ -59,7 +59,8 @@ class Calculator:
             os.makedirs(self.dir)
 
         for index,content in enumerate(self.input):
-            with open('{0}/{1}-try{2}.{3}'.format(self.dir,self.jobname,self.try_count,self.program.infiles[index]),'w') as inputfile:
+            #with open('{0}/{1}-try{2}.{3}'.format(self.dir,self.jobname,self.try_count,self.program.infiles[index]),'w') as inputfile:
+            with open(self.program.infiles[index].format(dir=self.dir,jobname=self.jobname,try_count=self.try_count), 'w') as inputfile:
                 inputfile.write(content)
 
     ############

--- a/workflowV2/calculator.py
+++ b/workflowV2/calculator.py
@@ -60,6 +60,7 @@ class Calculator:
 
         for index,content in enumerate(self.input):
             #with open('{0}/{1}-try{2}.{3}'.format(self.dir,self.jobname,self.try_count,self.program.infiles[index]),'w') as inputfile:
+            print(self.program.infiles[index])
             with open(self.program.infiles[index].format(dir=self.dir,jobname=self.jobname,try_count=self.try_count), 'w') as inputfile:
                 inputfile.write(content)
 

--- a/workflowV2/software/CREST.py
+++ b/workflowV2/software/CREST.py
@@ -184,7 +184,7 @@ class crest:
     def __init__(self,delete=['METADYN*','MRMSD','NORMMD*','*.tmp','wbo']):
         self.program_name = 'crest'
         self.infiles = ['{dir}{jobname}-try{try_count}.xyz','{dir}constrain.c','{dir}ref-try{try_count}.ref']
-        self.outfiles = ['out']
+        self.outfiles = ['{dir}{jobname}-try{try_count}.out']
         self.normal_termination_line = -1   #where to look to see if calculation was successful
         self.normal_termination_string = 'CREST terminated normally.'   #what to look for
         self.unessesary_files = delete

--- a/workflowV2/software/CREST.py
+++ b/workflowV2/software/CREST.py
@@ -183,7 +183,7 @@ class crest:
 #define attributes#
     def __init__(self,delete=['METADYN*','MRMSD','NORMMD*','*.tmp','wbo']):
         self.program_name = 'crest'
-        self.infiles = ['{dir}{jobname}-try{try_count}.xyz','constrain.c','ref-try{try_count}.ref']
+        self.infiles = ['{dir}{jobname}-try{try_count}.xyz','{dir}constrain.c','{dir}ref-try{try_count}.ref']
         self.outfiles = ['out']
         self.normal_termination_line = -1   #where to look to see if calculation was successful
         self.normal_termination_string = 'CREST terminated normally.'   #what to look for

--- a/workflowV2/software/CREST.py
+++ b/workflowV2/software/CREST.py
@@ -74,7 +74,7 @@ def CREST(mol,jobname,runtype,nproc=1,mem=1,time=default_time,partition=default_
     if len(mol.constraints) > 0:
         if not '-subrmsd' in arguments:
             arguments.append('-subrmsd')
-        arguments.append('-cinp {0}-try{1}.c'.format(jobname,try_count))
+        arguments.append('-cinp constrain.c'.format(jobname,try_count))
 
         constraintfile = ['$constrain']
         
@@ -97,7 +97,7 @@ def CREST(mol,jobname,runtype,nproc=1,mem=1,time=default_time,partition=default_
                 constrained_atoms.append(constraint[3]+1)
         
         constraintfile.append('force constant={0}'.format(crest_constraint_force_constrant))
-        constraintfile.append('reference={0}-try{1}.ref'.format(jobname,try_count))
+        constraintfile.append('reference=ref-try{0}.ref'.format(try_count))
         constraintfile.append('$metadyn')
 
         #get the list of atoms NOT constrained to include in the metadynamics
@@ -183,7 +183,7 @@ class crest:
 #define attributes#
     def __init__(self,delete=['METADYN*','MRMSD','NORMMD*','*.tmp','wbo']):
         self.program_name = 'crest'
-        self.infiles = ['xyz','c','ref']
+        self.infiles = ['{dir}{jobname}-try{try_count}.xyz','constrain.c','ref-try{try_count}.ref']
         self.outfiles = ['out']
         self.normal_termination_line = -1   #where to look to see if calculation was successful
         self.normal_termination_string = 'CREST terminated normally.'   #what to look for

--- a/workflowV2/software/CREST.py
+++ b/workflowV2/software/CREST.py
@@ -286,10 +286,8 @@ def confs(mol,line_number,line,output_lines,calculator):
                 x = float(x)
                 y = float(y)
                 z = float(z)
-                if atom == 'CL':
-                    atom = 'Cl'
-                elif atom == 'BR':
-                    atom = 'Br'
+                if len(atom) > 1:
+                    atom = atom[0] + atom[1:].lower()
                 xyz.append([atom,x,y,z])
                 atoms.append(atom)
                 coords.append([x,y,z])

--- a/workflowV2/software/GAUSSIAN.py
+++ b/workflowV2/software/GAUSSIAN.py
@@ -235,7 +235,7 @@ class gaussian:
     def __init__(self,delete=['*.chk','Gau*']):
         self.program_name = 'gaussian'
         self.infiles = ['{dir}{jobname}-try{try_count}.com']
-        self.outfiles = ['log']
+        self.outfiles = ['{dir}{jobname}-try{try_count}.log']
         self.normal_termination_line = -1   #where to look to see if calculation was successful
         self.normal_termination_string = 'Normal termination of Gaussian'   #what to look for
         self.unessesary_files = delete

--- a/workflowV2/software/GAUSSIAN.py
+++ b/workflowV2/software/GAUSSIAN.py
@@ -234,7 +234,7 @@ class gaussian:
 #define attributes#
     def __init__(self,delete=['*.chk','Gau*']):
         self.program_name = 'gaussian'
-        self.infiles = ['com']
+        self.infiles = ['{dir}{jobname}-try{try_count}.com']
         self.outfiles = ['log']
         self.normal_termination_line = -1   #where to look to see if calculation was successful
         self.normal_termination_string = 'Normal termination of Gaussian'   #what to look for


### PR DESCRIPTION
CREST constraint files are inconsistently read if the file name is > ~20 characters. This update reworks how input/output files are defined/written between the software interface and calculator object so that all CREST constraint files will be named 'constrain.c'